### PR TITLE
新着記事で新着以外を拾ってしまうバグの修正

### DIFF
--- a/domain/nicopedia/meta.go
+++ b/domain/nicopedia/meta.go
@@ -1,0 +1,9 @@
+package nicopedia
+
+import "time"
+
+type MetaData struct {
+	IsRedirect bool
+	FromTitle  string
+	CreateAt   time.Time
+}

--- a/domain/nicopedia/redirect.go
+++ b/domain/nicopedia/redirect.go
@@ -1,6 +1,0 @@
-package nicopedia
-
-type Redirect struct {
-	Exits bool
-	Title string
-}


### PR DESCRIPTION
実際の記事をスクレイピングし，初版作成日を確認するように変更
英語を書くほど元気が無いのでこれで．